### PR TITLE
Use node 18.18 in CI to match .nvmrc

### DIFF
--- a/.github/workflows/runtime-tests.yaml
+++ b/.github/workflows/runtime-tests.yaml
@@ -71,7 +71,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.14.0]
+        node-version: [18.14.0, 18.18.0]
 
     # Service containers to run with `runner-job`
     services:

--- a/.github/workflows/runtime-tests.yaml
+++ b/.github/workflows/runtime-tests.yaml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.14.0]
+        node-version: [18.14.0, 18.18.0]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Upgrade node version used in CI.
 
### Related Issues

### Checklist

- [ ] I have tested these changes locally and they work as expected.
- [x] I have added or updated tests to cover any new functionality or bug fixes.
- [ ] I have updated the documentation to reflect any changes or additions to the project.
- [x] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

Using matrix for now to see if it clarifies anything about recent test failures in Andrew's spike.