### PR TITLE
Add GET /docmap_for/doi

### DIFF
--- a/packages/http-client/src/contract.ts
+++ b/packages/http-client/src/contract.ts
@@ -21,6 +21,17 @@ export const contract = c.router({
     responses: {
       200: c.type<DocmapT>(),
     },
-    summary: 'Get information about this Docmaps API server',
+    summary: 'Get a docmap matching an IRI exactly',
+  },
+
+  getDocmapForDoi: {
+    method: 'GET',
+    path: '/docmap_for/doi',
+    query: c.type<{ subject: string }>(),
+    // TODO: id as arg?
+    responses: {
+      200: c.type<DocmapT>(),
+    },
+    summary: 'Get a docmap that describes a research artifact with this DOI',
   },
 })

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -13,6 +13,8 @@ The package/server is structured like this:
 | SPARQL processor/adapter | converts Docmaps semantics to SPARQL and uses `docmaps-sdk` to make objects from triples | 
 | SPARQL triplestore | Anything that supports SPARQL is allowed, we supply easy access to [oxigraph](https://github.com/oxigraph/oxigraph) |
 
+Note that use of SPARQL is optional but you would be required to write your own `BackendAdapter` layer that translates
+domain logic into queries for your specific backend (such as a relational database).
 
 ## Development and Testing
 
@@ -20,7 +22,7 @@ See the readme in repository root for general info about this monorepo.
 
 Dependencies for local development include:
 
-```bash
+```
 pnpm
 docker # with docker-compose
 curl
@@ -34,8 +36,12 @@ pnpm test:unit
 pnpm test:integration
 ```
 
-If you have never done this before, the tests may timeout due to invoking a `docker pull` for the `oxigraph` image, which
+**WARN:** If you have never done this before, the tests may timeout due to invoking a `docker pull` for the `oxigraph` image, which
 is used for a local triplestore to use during integration tests.
+
+## Running locally with Docker and Oxigraph
+
+See the instructions in repository root. You can invoke workspace root scripts like `pnpm run -w compose:up` wihout changing directory.
 
 ### Misc
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -36,7 +36,7 @@
     "@zazuko/rdf-vocabularies": "^2023.1.19",
     "commander": "^11.0.0",
     "cors": "^2.8.5",
-    "docmaps-sdk": "^0.11.2",
+    "docmaps-sdk": "^0.14.0",
     "express": "^4.18.2",
     "fetch-sparql-endpoint": "^4.0.0",
     "fp-ts": "^2.14.0",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -40,7 +40,6 @@
     "express": "^4.18.2",
     "fetch-sparql-endpoint": "^4.0.0",
     "fp-ts": "^2.14.0",
-    "immutable": "5.0.0-beta.4",
     "isomorphic-fetch": "^3.0.0",
     "n3": "^1.17.1",
     "oxigraph": "^0.3.19",

--- a/packages/runtime/src/adapter/sparql_adapter.ts
+++ b/packages/runtime/src/adapter/sparql_adapter.ts
@@ -3,13 +3,14 @@ import { CONSTRUCT, Construct, Describe } from '@tpluscode/sparql-builder'
 import { VALUES } from '@tpluscode/sparql-builder/expressions'
 import * as D from 'docmaps-sdk'
 import * as TE from 'fp-ts/lib/TaskEither'
+import * as E from 'fp-ts/lib/Either'
 import n3 from 'n3'
 import { collect } from 'streaming-iterables'
 import { pipe } from 'fp-ts/lib/pipeable'
 import factory from '@rdfjs/data-model'
 import { Set } from 'immutable'
-import { BackendAdapter } from '../types'
-// import util from 'util'
+import { BackendAdapter, ThingSpec } from '../types'
+import util from 'util'
 
 /** Inteface for an in-memory or over-the-web mechanism that accepts
  * SPARQL queries and returns triples.
@@ -21,7 +22,7 @@ export interface SparqlProcessor {
   // bindings(query: string): Promise<AsyncIterable<{ [key: string]: RDF.Term }>>
 }
 
-function FindDocmapQuery(iri: string): Construct | Describe {
+function FindDocmapQuery(iri: string): Construct {
   const subj = factory.namedNode(iri)
 
   const values = [{ map: subj }]
@@ -50,6 +51,55 @@ function FindDocmapQuery(iri: string): Construct | Describe {
   return q
 }
 
+function DocmapForThingIriQuery(iri: string): Construct {
+  const subj = factory.namedNode(iri)
+
+  const values = [{ thing: subj }]
+
+  // FIXME: use sparql builder more idiomatically
+  const q = CONSTRUCT`
+    ?s ?p ?o .
+  `.WHERE`
+    {
+      SELECT DISTINCT ?map ?s ?p WHERE {
+        ${VALUES(...values)}
+        ?map (!<>)+ ?s .
+        ?s ?p ?thing .
+      }
+    }
+    UNION
+    {
+      SELECT DISTINCT ?s ?p ?o WHERE {
+        ?map (!<>)+ ?s .
+        ?s ?p ?o .
+      }
+    }
+  `
+
+  return q
+}
+
+function DocmapForThingDoiQuery(doi: string): Construct {
+  const values = [{ doi: doi }]
+
+  // FIXME: use UNION to minimize the quads retrieved
+  const q = CONSTRUCT`
+    ?s ?p ?o .
+  `.WHERE`
+    {
+      SELECT DISTINCT ?map ?s0 ?s ?p ?o WHERE {
+        ${VALUES(...values)}
+        ?map (!<>)+ ?s0 .
+        ?s0 <http://prismstandard.org/namespaces/basic/2.0/doi> ?doi .
+        ?map (!<>)* ?s .
+        ?s ?p ?o .
+      }
+    }
+  `
+
+  return q
+}
+
 export class SparqlAdapter implements BackendAdapter {
   q: SparqlProcessor
 
@@ -70,8 +120,51 @@ export class SparqlAdapter implements BackendAdapter {
           (reason) => new Error(`failed to create quads from iterator: ${reason}`),
         ),
       ),
+      TE.chainEitherK((quads) => {
+        return quads.length > 0
+          ? E.right(quads)
+          : E.left(new Error('content not found for queried DOI'))
+      }),
       TE.map((quads: Array<RDF.Quad>) => {
         const deduped = [...Set(quads)] //TODO: ineffective, because WASM implements this structure as just `{__wbg_ptr}` which is always unique
+        return new n3.Store(deduped).match()
+      }),
+      TE.chain((stream: RDF.Stream) =>
+        g.pickStreamWithCodec(D.DocmapNormalizedFrame, D.Docmap, stream),
+      ),
+    )
+
+    return program
+  }
+
+  docmapForThing(thing: ThingSpec): TE.TaskEither<Error, D.DocmapT> {
+    let query: Construct
+    switch (thing.kind) {
+      case 'iri':
+        query = DocmapForThingIriQuery(thing.identifier)
+        throw 'not implemented'
+      case 'doi':
+        query = DocmapForThingDoiQuery(thing.identifier)
+    }
+
+    const g = new D.TypedGraph()
+
+    const program = pipe(
+      this.q.triples(query),
+      TE.chain((iter) =>
+        TE.tryCatch(
+          () => collect(iter),
+          (reason) => new Error(`failed to create quads from iterator: ${reason}`),
+        ),
+      ),
+      TE.chainEitherK((quads) => {
+        return quads.length > 0
+          ? E.right(quads)
+          : E.left(new Error('content not found for queried DOI'))
+      }),
+      TE.map((quads: Array<RDF.Quad>) => {
+        const deduped = [...Set(quads)] //TODO: ineffective, because WASM implements this structure as just `{__wbg_ptr}` which is always unique
+        const copy = new n3.Store(deduped)
         return new n3.Store(deduped).match()
       }),
       TE.chain((stream: RDF.Stream) =>

--- a/packages/runtime/src/adapter/sparql_adapter.ts
+++ b/packages/runtime/src/adapter/sparql_adapter.ts
@@ -12,6 +12,7 @@ import { pipe } from 'fp-ts/lib/pipeable'
 import factory from '@rdfjs/data-model'
 import { BackendAdapter, ThingSpec } from '../types'
 import util from 'util'
+import { Separated } from 'fp-ts/lib/Separated'
 
 /** Inteface for an in-memory or over-the-web mechanism that accepts
  * SPARQL queries and returns triples.
@@ -195,8 +196,8 @@ export class SparqlAdapter implements BackendAdapter {
           docmapIrisFromStore,
           A.map(docmapMatching(store)),
           A.sequence(T.ApplicativePar),
-          T.map(A.separate),
-          T.map((separated) => {
+          T.map<E.Either<Error, D.DocmapT>[], Separated<Error[], D.DocmapT[]>>(A.separate),
+          T.map((separated: Separated<Error[], D.DocmapT[]>) => {
             const first = separated.right[0]
             if (!first) {
               return E.left(

--- a/packages/runtime/src/adapter/sparql_adapter.ts
+++ b/packages/runtime/src/adapter/sparql_adapter.ts
@@ -142,6 +142,7 @@ export class SparqlAdapter implements BackendAdapter {
     switch (thing.kind) {
       case 'iri':
         query = DocmapForThingIriQuery(thing.identifier)
+        // FIXME: this case is not known and requires test implementation.
         throw 'not implemented'
       case 'doi':
         query = DocmapForThingDoiQuery(thing.identifier)

--- a/packages/runtime/src/adapter/sparql_adapter.ts
+++ b/packages/runtime/src/adapter/sparql_adapter.ts
@@ -80,17 +80,19 @@ function DocmapForThingIriQuery(iri: string): Construct {
 }
 
 function DocmapForThingDoiQuery(doi: string): Construct {
-  const values = [{ doi: doi }]
+  const doiLit = factory.literal(doi)
+  const values = [{ doi: doiLit }]
 
   // FIXME: use UNION to minimize the quads retrieved
   const q = CONSTRUCT`
     ?s ?p ?o .
   `.WHERE`
     {
-      SELECT DISTINCT ?map ?s0 ?s ?p ?o WHERE {
+      SELECT DISTINCT ?s ?p ?o WHERE {
         ${VALUES(...values)}
-        ?map (!<>)+ ?s0 .
         ?s0 <http://prismstandard.org/namespaces/basic/2.0/doi> ?doi .
+        ?map (!<>)+ ?s0 .
+        ?map <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/pwo/Workflow> .
         ?map (!<>)* ?s .
         ?s ?p ?o .
       }

--- a/packages/runtime/src/api.ts
+++ b/packages/runtime/src/api.ts
@@ -1,4 +1,4 @@
-import type { ApiInfo, BackendAdapter } from './types'
+import type { ApiInfo, BackendAdapter, ThingSpec } from './types'
 import * as TE from 'fp-ts/TaskEither'
 import * as D from 'docmaps-sdk'
 
@@ -49,8 +49,12 @@ export class ApiInstance {
 
   // FIXME: it is likely that this needs to be called docmap_by_iri instead.
   // Current rationale for this name is that the IRI-based docmap "may not"
-  // be implicit in any user of this contract, but taht is pretty weak.
+  // be implicit in any user of this contract, but that is pretty weak.
   get_docmap_by_id(id: string): TE.TaskEither<Error, D.DocmapT> {
     return this.adapter.docmapWithIri(id)
+  }
+
+  get_docmap_for_thing(s: ThingSpec): TE.TaskEither<Error, D.DocmapT> {
+    return this.adapter.docmapForThing(s)
   }
 }

--- a/packages/runtime/src/httpserver/server.ts
+++ b/packages/runtime/src/httpserver/server.ts
@@ -87,6 +87,23 @@ export class HttpServer {
           body: result.right,
         }
       },
+      getDocmapForDoi: async (req) => {
+        const doi = req.query.subject
+        console.log(doi)
+        const result = await this.api.get_docmap_for_thing({ identifier: doi, kind: 'doi' })()
+
+        if (isLeft(result)) {
+          return {
+            status: 404, // FIXME: more expressive errors.
+            body: result.left,
+          }
+        }
+
+        return {
+          status: 200,
+          body: result.right,
+        }
+      },
     })
 
     // FIXME: resolve this awkward use of typescript ignores. The only

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -14,7 +14,13 @@ export type ApiInfo = {
   }[]
 }
 
+export type ThingSpec = {
+  identifier: string
+  kind: 'iri' | 'doi'
+}
+
 // TODO is this the same as the Client?
 export interface BackendAdapter {
   docmapWithIri(iri: string): TE.TaskEither<Error, D.DocmapT>
+  docmapForThing(thing: ThingSpec): TE.TaskEither<Error, D.DocmapT>
 }

--- a/packages/runtime/test/__fixtures__/docmaps.ts
+++ b/packages/runtime/test/__fixtures__/docmaps.ts
@@ -118,6 +118,142 @@ _:b2 <http://purl.org/spar/pwo/hasPreviousStep> _:b1 .
 <https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/get-by-doi?preprint_doi=10.1101%2F2022.11.08.515698> <http://purl.org/spar/pwo/hasStep> _:b2 .
 <https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/get-by-doi?preprint_doi=10.1101%2F2022.11.08.515698> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/pwo/Workflow> .
 `
+export const elife_02 = `
+<https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/by-publisher/elife/get-by-doi?preprint_doi=10.1101%2F2022.11.08.515698> <http://purl.org/dc/terms/created> "2021-11-28T11:30:05+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+<https://sciety.org/groups/elife> <http://xmlns.com/foaf/0.1/accountServiceHomepage> "https://sciety.org" .
+<https://elifesciences.org/> <http://xmlns.com/foaf/0.1/logo> "https://sciety.org/static/groups/elife--b560187e-f2fb-4ff9-a861-a204f3fc0fb0.png" .
+<https://elifesciences.org/> <http://xmlns.com/foaf/0.1/name> "eLife" .
+<https://elifesciences.org/> <http://xmlns.com/foaf/0.1/onlineAccount> <https://sciety.org/groups/elife> .
+<https://elifesciences.org/> <http://xmlns.com/foaf/0.1/homepage> "https://elifesciences.org/" .
+<https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/by-publisher/elife/get-by-doi?preprint_doi=10.1101%2F2022.11.08.515698> <http://purl.org/dc/terms/publisher> <https://elifesciences.org/> .
+<https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/by-publisher/elife/get-by-doi?preprint_doi=10.1101%2F2022.11.08.515698> <http://purl.org/spar/pwo/hasFirstStep> _:b0 .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/Preprint> .
+_:b1 <http://prismstandard.org/namespaces/basic/2.0/doi> "10.1101/2022.11.08.515698" .
+_:b1 <http://purl.org/spar/fabio/hasURL> "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v2"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b1 <http://prismstandard.org/namespaces/basic/2.0/publicationDate> "2022-11-22"^^<http://www.w3.org/2001/XMLSchema#date> .
+_:b2 <http://purl.org/spar/pwo/produces> _:b1 .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/Preprint> .
+_:b3 <http://prismstandard.org/namespaces/basic/2.0/doi> "10.1101/2022.11.08.515698" .
+_:b4 <http://purl.org/spar/pso/isStatusHeldBy> _:b3 .
+_:b4 <http://purl.org/spar/pso/withStatus> <http://purl.org/spar/pso/manuscript-published> .
+_:b0 <http://www.ontologydesignpatterns.org/cp/owl/taskexecution.owl#isExecutedIn> _:b2 .
+_:b0 <http://purl.org/spar/pso/resultsInAcquiring> _:b4 .
+_:b0 <http://purl.org/spar/pwo/hasNextStep> _:b1 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/Preprint> .
+_:b5 <http://prismstandard.org/namespaces/basic/2.0/doi> "10.7554/eLife.85111.1" .
+_:b6 <http://purl.org/spar/pwo/produces> _:b5 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/Preprint> .
+_:b7 <http://prismstandard.org/namespaces/basic/2.0/doi> "10.1101/2022.11.08.515698" .
+_:b8 <http://purl.org/spar/pso/isStatusHeldBy> _:b7 .
+_:b8 <http://purl.org/spar/pso/withStatus> <http://purl.org/spar/pso/under-review> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/Preprint> .
+_:b9 <http://prismstandard.org/namespaces/basic/2.0/doi> "10.7554/eLife.85111.1" .
+_:b10 <http://purl.org/spar/pso/isStatusHeldBy> _:b9 .
+_:b10 <http://purl.org/spar/pso/withStatus> <http://purl.org/spar/pso/draft> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/Preprint> .
+_:b11 <http://prismstandard.org/namespaces/basic/2.0/doi> "10.1101/2022.11.08.515698" .
+_:b11 <http://purl.org/spar/fabio/hasURL> "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v2"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b1 <http://www.ontologydesignpatterns.org/cp/owl/taskexecution.owl#isExecutedIn> _:b6 .
+_:b1 <http://purl.org/spar/pso/resultsInAcquiring> _:b8 .
+_:b1 <http://purl.org/spar/pso/resultsInAcquiring> _:b10 .
+_:b1 <http://purl.org/spar/pwo/needs> _:b11 .
+_:b1 <http://purl.org/spar/pwo/hasNextStep> _:b2 .
+_:b1 <http://purl.org/spar/pwo/hasPreviousStep> _:b0 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/WebPage> .
+_:b12 <http://purl.org/spar/fabio/hasURL> "https://hypothes.is/a/EzFzxJsrEe28DyfQK4aPhg"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/WebPage> .
+_:b13 <http://purl.org/spar/fabio/hasURL> "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:EzFzxJsrEe28DyfQK4aPhg"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/WebPage> .
+_:b14 <http://purl.org/spar/fabio/hasURL> "https://sciety.org/evaluations/hypothesis:EzFzxJsrEe28DyfQK4aPhg/content"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/Reply> .
+_:b15 <http://prismstandard.org/namespaces/basic/2.0/publicationDate> "2023-01-23T14:34:42.571948+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+_:b15 <http://prismstandard.org/namespaces/basic/2.0/doi> "10.7554/eLife.85111.1.sa1" .
+_:b15 <http://purl.org/spar/fabio/hasURL> "https://doi.org/10.7554/eLife.85111.1.sa1"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b15 <http://purl.org/spar/fabio/hasManifestation> _:b12 .
+_:b15 <http://purl.org/spar/fabio/hasManifestation> _:b13 .
+_:b15 <http://purl.org/spar/fabio/hasManifestation> _:b14 .
+_:b16 <http://purl.org/spar/pwo/produces> _:b15 .
+_:b17 <http://xmlns.com/foaf/0.1/name> "anonymous" .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
+_:b18 <http://purl.org/spar/pro/isHeldBy> _:b17 .
+_:b18 <http://purl.org/spar/pro/withRole> <http://purl.org/spar/pro/peer-reviewer> .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/WebPage> .
+_:b19 <http://purl.org/spar/fabio/hasURL> "https://hypothes.is/a/E9MOvpsrEe2w6nds1t6xxQ"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/WebPage> .
+_:b20 <http://purl.org/spar/fabio/hasURL> "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:E9MOvpsrEe2w6nds1t6xxQ"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/WebPage> .
+_:b21 <http://purl.org/spar/fabio/hasURL> "https://sciety.org/evaluations/hypothesis:E9MOvpsrEe2w6nds1t6xxQ/content"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/ReviewArticle> .
+_:b22 <http://prismstandard.org/namespaces/basic/2.0/publicationDate> "2023-01-23T14:34:43.676466+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+_:b22 <http://prismstandard.org/namespaces/basic/2.0/doi> "10.7554/eLife.85111.1.sa2" .
+_:b22 <http://purl.org/spar/fabio/hasURL> "https://doi.org/10.7554/eLife.85111.1.sa2"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b22 <http://purl.org/spar/fabio/hasManifestation> _:b19 .
+_:b22 <http://purl.org/spar/fabio/hasManifestation> _:b20 .
+_:b22 <http://purl.org/spar/fabio/hasManifestation> _:b21 .
+_:b23 <http://purl.org/spar/pro/isDocumentContextFor> _:b18 .
+_:b23 <http://purl.org/spar/pwo/produces> _:b22 .
+_:b24 <http://xmlns.com/foaf/0.1/name> "anonymous" .
+_:b24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
+_:b25 <http://purl.org/spar/pro/isHeldBy> _:b24 .
+_:b25 <http://purl.org/spar/pro/withRole> <http://purl.org/spar/pro/peer-reviewer> .
+_:b26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/WebPage> .
+_:b26 <http://purl.org/spar/fabio/hasURL> "https://hypothes.is/a/FD5EmpsrEe28RaOWOszMEw"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/WebPage> .
+_:b27 <http://purl.org/spar/fabio/hasURL> "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:FD5EmpsrEe28RaOWOszMEw"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/WebPage> .
+_:b28 <http://purl.org/spar/fabio/hasURL> "https://sciety.org/evaluations/hypothesis:FD5EmpsrEe28RaOWOszMEw/content"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/ReviewArticle> .
+_:b29 <http://prismstandard.org/namespaces/basic/2.0/publicationDate> "2023-01-23T14:34:44.369019+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+_:b29 <http://prismstandard.org/namespaces/basic/2.0/doi> "10.7554/eLife.85111.1.sa3" .
+_:b29 <http://purl.org/spar/fabio/hasURL> "https://doi.org/10.7554/eLife.85111.1.sa3"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b29 <http://purl.org/spar/fabio/hasManifestation> _:b26 .
+_:b29 <http://purl.org/spar/fabio/hasManifestation> _:b27 .
+_:b29 <http://purl.org/spar/fabio/hasManifestation> _:b28 .
+_:b30 <http://purl.org/spar/pro/isDocumentContextFor> _:b25 .
+_:b30 <http://purl.org/spar/pwo/produces> _:b29 .
+_:b31 <http://xmlns.com/foaf/0.1/name> "Brice Bathellier" .
+_:b31 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
+_:b32 <http://purl.org/spar/pro/isHeldBy> _:b31 .
+_:b32 <http://purl.org/spar/pro/withRole> <http://purl.org/spar/pro/editor> .
+_:b33 <http://xmlns.com/foaf/0.1/name> "Kate Wassum" .
+_:b33 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
+_:b34 <http://purl.org/spar/pro/isHeldBy> _:b33 .
+_:b34 <http://purl.org/spar/pro/withRole> <http://purl.org/spar/pro/senior-editor> .
+_:b35 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/WebPage> .
+_:b35 <http://purl.org/spar/fabio/hasURL> "https://hypothes.is/a/FMwbnpsrEe2mVPtbQf2X2w"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b36 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/WebPage> .
+_:b36 <http://purl.org/spar/fabio/hasURL> "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:FMwbnpsrEe2mVPtbQf2X2w"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b37 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/WebPage> .
+_:b37 <http://purl.org/spar/fabio/hasURL> "https://sciety.org/evaluations/hypothesis:FMwbnpsrEe2mVPtbQf2X2w/content"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b38 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/ExecutiveSummary> .
+_:b38 <http://prismstandard.org/namespaces/basic/2.0/publicationDate> "2023-01-23T14:34:45.299882+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+_:b38 <http://prismstandard.org/namespaces/basic/2.0/doi> "10.7554/eLife.85111.1.sa4" .
+_:b38 <http://purl.org/spar/fabio/hasURL> "https://doi.org/10.7554/eLife.85111.1.sa4"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b38 <http://purl.org/spar/fabio/hasManifestation> _:b35 .
+_:b38 <http://purl.org/spar/fabio/hasManifestation> _:b36 .
+_:b38 <http://purl.org/spar/fabio/hasManifestation> _:b37 .
+_:b39 <http://purl.org/spar/pro/isDocumentContextFor> _:b32 .
+_:b39 <http://purl.org/spar/pro/isDocumentContextFor> _:b34 .
+_:b39 <http://purl.org/spar/pwo/produces> _:b38 .
+_:b40 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/Preprint> .
+_:b40 <http://prismstandard.org/namespaces/basic/2.0/doi> "10.1101/2022.11.08.515698" .
+_:b41 <http://purl.org/spar/pso/isStatusHeldBy> _:b40 .
+_:b41 <http://purl.org/spar/pso/withStatus> <http://purl.org/spar/pso/peer-reviewed> .
+_:b42 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/fabio/Preprint> .
+_:b42 <http://prismstandard.org/namespaces/basic/2.0/doi> "10.1101/2022.11.08.515698" .
+_:b42 <http://purl.org/spar/fabio/hasURL> "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v2"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+_:b2 <http://www.ontologydesignpatterns.org/cp/owl/taskexecution.owl#isExecutedIn> _:b16 .
+_:b2 <http://www.ontologydesignpatterns.org/cp/owl/taskexecution.owl#isExecutedIn> _:b23 .
+_:b2 <http://www.ontologydesignpatterns.org/cp/owl/taskexecution.owl#isExecutedIn> _:b30 .
+_:b2 <http://www.ontologydesignpatterns.org/cp/owl/taskexecution.owl#isExecutedIn> _:b39 .
+_:b2 <http://purl.org/spar/pso/resultsInAcquiring> _:b41 .
+_:b2 <http://purl.org/spar/pwo/needs> _:b42 .
+_:b2 <http://purl.org/spar/pwo/hasPreviousStep> _:b1 .
+<https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/by-publisher/elife/get-by-doi?preprint_doi=10.1101%2F2022.11.08.515698> <http://purl.org/spar/pwo/hasStep> _:b0 .
+<https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/by-publisher/elife/get-by-doi?preprint_doi=10.1101%2F2022.11.08.515698> <http://purl.org/spar/pwo/hasStep> _:b1 .
+<https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/by-publisher/elife/get-by-doi?preprint_doi=10.1101%2F2022.11.08.515698> <http://purl.org/spar/pwo/hasStep> _:b2 .
+<https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/by-publisher/elife/get-by-doi?preprint_doi=10.1101%2F2022.11.08.515698> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/spar/pwo/Workflow> .
+`
 
 export const embo_01 = `
 _:b1 <http://xmlns.com/foaf/0.1/name> "review commons" .
@@ -257,6 +393,12 @@ export function CreateDatastore() {
   )
   backend.store.load(
     elife_01, // data
+    'application/n-triples', // mime type
+    TEXT_EX_BASE_IRI,
+    graph,
+  )
+  backend.store.load(
+    elife_02, // data
     'application/n-triples', // mime type
     TEXT_EX_BASE_IRI,
     graph,

--- a/packages/runtime/test/integration/assets/docmaps-example-elife-01.jsonld.nt
+++ b/packages/runtime/test/integration/assets/docmaps-example-elife-01.jsonld.nt
@@ -1,4 +1,4 @@
-<https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/get-by-doi?preprint_doi=10.1101%2F2022.11.08.515698> <http://purl.org/dc/terms/created> "2022-11-28T11:30:05+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+<https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/get-by-doi?preprint_doi=10.1101%2F2022.11.08.515698> <http://purl.org/dc/terms/created> "2022-12-28T11:30:05+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
 <https://sciety.org/groups/elife> <http://xmlns.com/foaf/0.1/accountServiceHomepage> "https://sciety.org" .
 <https://elifesciences.org/> <http://xmlns.com/foaf/0.1/logo> "https://sciety.org/static/groups/elife--b560187e-f2fb-4ff9-a861-a204f3fc0fb0.png" .
 <https://elifesciences.org/> <http://xmlns.com/foaf/0.1/name> "eLife" .

--- a/packages/runtime/test/integration/httpserver.test.ts
+++ b/packages/runtime/test/integration/httpserver.test.ts
@@ -60,3 +60,27 @@ test.serial('it serves /docmap endpoint', async (t) => {
     })
   }, t.log)
 })
+
+test.serial('it serves /docmap_for/doi endpoint', async (t) => {
+  await withNewServer(async (_s) => {
+    const client = MakeHttpClient({
+      baseUrl: 'http://localhost:33033',
+      baseHeaders: {},
+    })
+    const testDoi1 = '10.1101/2021.03.24.436774'
+
+    const resp = await client.getDocmapForDoi({
+      query: { subject: testDoi1 },
+    })
+
+    t.is(resp.status, 200, `failed with this response: ${inspect(resp, { depth: null })}`)
+
+    const dm = resp.body as D.DocmapT
+
+    t.deepEqual(dm.id, 'https://eeb.embo.org/api/v2/docmap/10.1101/2021.03.24.436774')
+    t.deepEqual(dm.publisher, {
+      name: 'review commons',
+      url: 'https://reviewcommons.org/',
+    })
+  }, t.log)
+})

--- a/packages/runtime/test/integration/httpserver.test.ts
+++ b/packages/runtime/test/integration/httpserver.test.ts
@@ -100,8 +100,14 @@ test.serial('it serves /docmap_for/doi endpoint', async (t) => {
       'https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/get-by-doi?preprint_doi=10.1101%2F2022.11.08.515698',
     )
     t.deepEqual(dm2.publisher, {
-      name: 'review commons',
-      url: 'https://reviewcommons.org/',
+      account: {
+        id: 'https://sciety.org/groups/elife',
+        service: 'https://sciety.org/',
+      },
+      homepage: 'https://elifesciences.org/',
+      id: 'https://elifesciences.org/',
+      logo: 'https://sciety.org/static/groups/elife--b560187e-f2fb-4ff9-a861-a204f3fc0fb0.png',
+      name: 'eLife',
     })
   }, t.log)
 })

--- a/packages/runtime/test/integration/httpserver.test.ts
+++ b/packages/runtime/test/integration/httpserver.test.ts
@@ -19,6 +19,7 @@ test.serial('it serves info endpoint', async (t) => {
     t.is(info.status, 200)
     t.is(info.headers.get('Access-Control-Allow-Origin'), '*')
     t.deepEqual(info.body, {
+      // FIXME: this is technically a lie, because it is not prefixed /docmaps/v1
       api_url: 'http://localhost:33033/docmaps/v1/',
       api_version: API_VERSION,
       ephemeral_document_expiry: {
@@ -79,6 +80,26 @@ test.serial('it serves /docmap_for/doi endpoint', async (t) => {
 
     t.deepEqual(dm.id, 'https://eeb.embo.org/api/v2/docmap/10.1101/2021.03.24.436774')
     t.deepEqual(dm.publisher, {
+      name: 'review commons',
+      url: 'https://reviewcommons.org/',
+    })
+
+    // test handling case where multiples exist
+    const testDoi2 = '10.1101/2022.11.08.515698'
+
+    const resp2 = await client.getDocmapForDoi({
+      query: { subject: testDoi2 },
+    })
+
+    t.is(resp2.status, 200, `failed with this response: ${inspect(resp, { depth: null })}`)
+
+    const dm2 = resp2.body as D.DocmapT
+
+    t.deepEqual(
+      dm2.id,
+      'https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/get-by-doi?preprint_doi=10.1101%2F2022.11.08.515698',
+    )
+    t.deepEqual(dm2.publisher, {
       name: 'review commons',
       url: 'https://reviewcommons.org/',
     })

--- a/packages/runtime/test/unit/api.test.ts
+++ b/packages/runtime/test/unit/api.test.ts
@@ -100,5 +100,7 @@ test('docmap_for: consults the adapter', async (t) => {
     10,
   ).get_docmap_for_thing(spec)()
 
+  // TODO awkward use of `await .. ()`, is there a more natural way?
+  // The alternative is all that `rightAnd` business in docmaps-sdk
   t.deepEqual(res, await TE.of(dm_content)())
 })

--- a/packages/runtime/test/unit/api.test.ts
+++ b/packages/runtime/test/unit/api.test.ts
@@ -5,6 +5,7 @@ import * as TE from 'fp-ts/lib/TaskEither'
 import * as D from 'docmaps-sdk'
 
 import { deepEqual, mock, instance, when } from 'ts-mockito'
+import { ThingSpec } from '../../src/types'
 
 // TODO: export this in shared module
 export function whenThenRight<T, E, V>(
@@ -72,5 +73,32 @@ test('docmap_by_id: consults the adapter', async (t) => {
 
   // TODO awkward use of `await .. ()`, is there a more natural way?
   // The alternative is all that `rightAnd` business in docmaps-sdk
+  t.deepEqual(res, await TE.of(dm_content)())
+})
+
+test('docmap_for: consults the adapter', async (t) => {
+  const adapterC = mock(SparqlAdapter)
+
+  const dm_content: D.DocmapT = {
+    '@context': 'https://w3id.org/docmaps/context.jsonld',
+    type: 'docmap',
+    id: 'http://ex/test-docmap',
+    publisher: {},
+    created: TEST_DATE,
+  }
+
+  const spec: ThingSpec = { identifier: '10.0000/test-thing', kind: 'doi' }
+  whenThenRight(adapterC.docmapForThing, spec, dm_content)
+
+  const adapter = instance(adapterC)
+
+  const res = await new ApiInstance(
+    adapter,
+    new URL('https://example.com'),
+    [new URL('https://other.com')],
+    30,
+    10,
+  ).get_docmap_for_thing(spec)()
+
   t.deepEqual(res, await TE.of(dm_content)())
 })

--- a/packages/runtime/test/unit/sparql.test.ts
+++ b/packages/runtime/test/unit/sparql.test.ts
@@ -33,6 +33,35 @@ test('docmapForThing: extracts a realistic docmap from a sparql backend when the
   t.is(Object.keys(steps).length, 3)
 })
 
+test('docmapForThing: extracts a realistic docmap from a sparql backend when there are multiple candidates', async (t) => {
+  const backend = fixtures.CreateDatastore()
+
+  const processor = new SparqlAdapter(backend)
+
+  const docmap = await processor.docmapForThing({
+    identifier: '10.1101/2022.11.08.515698',
+    kind: 'doi',
+  })()
+
+  if (E.isLeft(docmap)) {
+    t.fail(`got error instead of docmap: ${inspect(docmap.left, { depth: 4 })}`)
+    return
+  }
+
+  t.is(
+    docmap.right.id,
+    'https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/get-by-doi?preprint_doi=10.1101%2F2022.11.08.515698',
+  )
+
+  const steps = docmap.right.steps
+  if (!steps) {
+    t.fail('expected to find steps, but was null')
+    return
+  }
+
+  t.is(Object.keys(steps).length, 3)
+})
+
 test('docmapForThing: returns a failure case if no docmap can be found for a doi', async (t) => {
   const backend = fixtures.CreateDatastore()
 

--- a/packages/runtime/test/unit/sparql.test.ts
+++ b/packages/runtime/test/unit/sparql.test.ts
@@ -4,7 +4,54 @@ import * as E from 'fp-ts/lib/Either'
 import { inspect } from 'util'
 import * as fixtures from '../__fixtures__/docmaps'
 
-test('constructs and extracts a realistic docmap from a sparql backend', async (t) => {
+test('docmapForThing: extracts a realistic docmap from a sparql backend when the steps already exist', async (t) => {
+  const backend = fixtures.CreateDatastore()
+
+  const processor = new SparqlAdapter(backend)
+
+  const docmap = await processor.docmapForThing({
+    identifier: '10.1101/2022.11.08.515698',
+    kind: 'doi',
+  })()
+
+  if (E.isLeft(docmap)) {
+    t.fail(`got error instead of docmap: ${inspect(docmap.left, { depth: 4 })}`)
+    return
+  }
+
+  t.is(
+    docmap.right.id,
+    'https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/get-by-doi?preprint_doi=10.1101%2F2022.11.08.515698',
+  )
+
+  const steps = docmap.right.steps
+  if (!steps) {
+    t.fail('expected to find steps, but was null')
+    return
+  }
+
+  t.is(Object.keys(steps).length, 3)
+})
+
+test('docmapForThing: returns a failure case if no docmap can be found for a doi', async (t) => {
+  const backend = fixtures.CreateDatastore()
+
+  const processor = new SparqlAdapter(backend)
+
+  const docmap = await processor.docmapForThing({
+    identifier: '10.1101/2022.11.08.nonexistent',
+    kind: 'doi',
+  })()
+
+  if (E.isRight(docmap)) {
+    t.fail(`got docmap instead of error: ${inspect(docmap.right, { depth: 4 })}`)
+    return
+  }
+
+  t.regex(docmap.left.message, /not found/)
+})
+
+test('docmapWithiri: constructs and extracts a realistic docmap from a sparql backend', async (t) => {
   const backend = fixtures.CreateDatastore()
 
   const processor = new SparqlAdapter(backend)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,7 +101,7 @@ importers:
         version: 2.0.0
       '@tpluscode/sparql-builder':
         specifier: ^0.3.31
-        version: 0.3.31(@zazuko/rdf-vocabularies@2023.1.19)(clownface@1.5.1)(safe-identifier@0.4.2)(sparql-http-client@2.4.2)(ts-morph@19.0.0)(ts-node@10.9.1)
+        version: 0.3.31(@zazuko/rdf-vocabularies@2023.1.19)(clownface@1.5.1)(safe-identifier@0.4.2)(sparql-http-client@2.4.2)(ts-morph@20.0.0)(ts-node@10.9.1)
       '@ts-rest/core':
         specifier: ^3.30.2
         version: 3.30.2(zod@3.22.2)
@@ -121,8 +121,8 @@ importers:
         specifier: ^2.8.5
         version: 2.8.5
       docmaps-sdk:
-        specifier: ^0.11.2
-        version: 0.11.2
+        specifier: ^0.14.0
+        version: 0.14.0
       express:
         specifier: ^4.18.2
         version: 4.18.2
@@ -278,7 +278,7 @@ packages:
     dependencies:
       ky: 0.33.3
       ky-universal: 0.11.0(ky@0.33.3)
-      undici: 5.23.0
+      undici: 5.26.3
     transitivePeerDependencies:
       - web-streams-polyfill
     dev: false
@@ -513,6 +513,11 @@ packages:
     resolution: {integrity: sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
+
+  /@fastify/busboy@2.0.0:
+    resolution: {integrity: sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==}
+    engines: {node: '>=14'}
+    dev: false
 
   /@humanwhocodes/config-array@0.11.10:
     resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}
@@ -925,7 +930,7 @@ packages:
     resolution: {integrity: sha512-HP5DCmhyfVuQuk58AO5vzNY+dIFVHe2oHY8NX2K+3XmrTmu/yzrFzPbDeU9Cwr71XC4RifEMoksIg+8jnhxmfQ==}
     dependencies:
       '@rdfjs/sink': 2.0.0
-      jsonld: 8.2.0
+      jsonld: 8.3.1
       readable-stream: 4.4.2
       stream-chunks: 1.0.0
     transitivePeerDependencies:
@@ -1110,7 +1115,7 @@ packages:
       defer-to-connect: 1.1.3
     dev: true
 
-  /@tpluscode/rdf-ns-builders@2.0.1(@zazuko/rdf-vocabularies@2023.1.19)(clownface@1.5.1)(safe-identifier@0.4.2)(ts-morph@19.0.0)(ts-node@10.9.1):
+  /@tpluscode/rdf-ns-builders@2.0.1(@zazuko/rdf-vocabularies@2023.1.19)(clownface@1.5.1)(safe-identifier@0.4.2)(ts-morph@20.0.0)(ts-node@10.9.1):
     resolution: {integrity: sha512-P/pwfjhcj/JOZF3epheHiDd/f9tSkceydQBqBuqThpNX2NIg+4BSgwtG2YfKBa24mmGFfyzN6RVeFclhA8wZBw==}
     hasBin: true
     peerDependencies:
@@ -1128,17 +1133,17 @@ packages:
       commander: 7.2.0
       fs-extra: 10.1.0
       safe-identifier: 0.4.2
-      ts-morph: 19.0.0
+      ts-morph: 20.0.0
       ts-node: 10.9.1(@types/node@18.17.4)(typescript@4.9.5)
     dev: false
 
-  /@tpluscode/rdf-string@0.2.27(clownface@1.5.1)(safe-identifier@0.4.2)(ts-morph@19.0.0)(ts-node@10.9.1):
+  /@tpluscode/rdf-string@0.2.27(clownface@1.5.1)(safe-identifier@0.4.2)(ts-morph@20.0.0)(ts-node@10.9.1):
     resolution: {integrity: sha512-+h7FdEE9AwP+B0kA2u0lScWq0+wIfpAcsau6cHZRQfToTCQjq+xo5eyGqzC96SmVfULl73DHys5DE/VOtA3Ewg==}
     dependencies:
       '@rdf-esm/data-model': 0.5.4
       '@rdf-esm/term-map': 0.5.1
       '@rdfjs/types': 1.1.0
-      '@tpluscode/rdf-ns-builders': 2.0.1(@zazuko/rdf-vocabularies@2023.1.19)(clownface@1.5.1)(safe-identifier@0.4.2)(ts-morph@19.0.0)(ts-node@10.9.1)
+      '@tpluscode/rdf-ns-builders': 2.0.1(@zazuko/rdf-vocabularies@2023.1.19)(clownface@1.5.1)(safe-identifier@0.4.2)(ts-morph@20.0.0)(ts-node@10.9.1)
       '@zazuko/rdf-vocabularies': 2023.1.19
     transitivePeerDependencies:
       - clownface
@@ -1147,7 +1152,7 @@ packages:
       - ts-node
     dev: false
 
-  /@tpluscode/sparql-builder@0.3.31(@zazuko/rdf-vocabularies@2023.1.19)(clownface@1.5.1)(safe-identifier@0.4.2)(sparql-http-client@2.4.2)(ts-morph@19.0.0)(ts-node@10.9.1):
+  /@tpluscode/sparql-builder@0.3.31(@zazuko/rdf-vocabularies@2023.1.19)(clownface@1.5.1)(safe-identifier@0.4.2)(sparql-http-client@2.4.2)(ts-morph@20.0.0)(ts-node@10.9.1):
     resolution: {integrity: sha512-Q5D5sdo2hx2yfP/8mf6B2vEFJydpC/2qVqZqsl8jyFys8CYVGQY8+JcbiiLwZsxgQ4rJOrsf6hxjtlaOKggLCA==}
     peerDependencies:
       sparql-http-client: ^2.2.0
@@ -1155,8 +1160,8 @@ packages:
       '@rdf-esm/data-model': 0.5.4
       '@rdf-esm/term-set': 0.5.0
       '@rdfjs/types': 1.1.0
-      '@tpluscode/rdf-ns-builders': 2.0.1(@zazuko/rdf-vocabularies@2023.1.19)(clownface@1.5.1)(safe-identifier@0.4.2)(ts-morph@19.0.0)(ts-node@10.9.1)
-      '@tpluscode/rdf-string': 0.2.27(clownface@1.5.1)(safe-identifier@0.4.2)(ts-morph@19.0.0)(ts-node@10.9.1)
+      '@tpluscode/rdf-ns-builders': 2.0.1(@zazuko/rdf-vocabularies@2023.1.19)(clownface@1.5.1)(safe-identifier@0.4.2)(ts-morph@20.0.0)(ts-node@10.9.1)
+      '@tpluscode/rdf-string': 0.2.27(clownface@1.5.1)(safe-identifier@0.4.2)(ts-morph@20.0.0)(ts-node@10.9.1)
       '@types/sparql-http-client': 2.2.8
       debug: 4.3.4
       sparql-http-client: 2.4.2
@@ -1169,8 +1174,8 @@ packages:
       - ts-node
     dev: false
 
-  /@ts-morph/common@0.20.0:
-    resolution: {integrity: sha512-7uKjByfbPpwuzkstL3L5MQyuXPSKdoNG93Fmi2JoDcTf3pEP731JdRFAduRVkOs8oqxPsXKA+ScrWkdQ8t/I+Q==}
+  /@ts-morph/common@0.21.0:
+    resolution: {integrity: sha512-ES110Mmne5Vi4ypUKrtVQfXFDtCsDXiUiGxF6ILVlE90dDD4fdpC1LSjydl/ml7xJWKSDZwUYD2zkOePMSrPBA==}
     dependencies:
       fast-glob: 3.3.1
       minimatch: 7.4.6
@@ -1878,13 +1883,6 @@ packages:
       run-applescript: 5.0.0
     dev: true
 
-  /busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
-    dependencies:
-      streamsearch: 1.1.0
-    dev: false
-
   /bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -2446,8 +2444,9 @@ packages:
       path-type: 4.0.0
     dev: true
 
-  /docmaps-sdk@0.11.2:
-    resolution: {integrity: sha512-iKAdWWHW0aA+U759q8/di+7Ut27+lIP18yxfW2HPzBbUgq2AbqKzLCr7dAG1i3bFcOnCPJ2D0y//tGwGIJfbRQ==}
+  /docmaps-sdk@0.14.0:
+    resolution: {integrity: sha512-3F23bp+SEuxmO6PdwyO/Wqk+ABTvGnZ9Bqc2pOxx91z9n/hRmxQVb3PZkO3fvpZF6End1Ky+JL8sAKvkWE9T/w==}
+    engines: {node: '>=18.14.0'}
     dependencies:
       '@rdfjs/data-model': 2.0.1
       '@rdfjs/parser-n3': 2.0.1
@@ -2457,7 +2456,7 @@ packages:
       io-ts-types: 0.5.19(fp-ts@2.16.1)(io-ts@2.2.20)(monocle-ts@2.3.13)(newtype-ts@0.3.5)
       monocle-ts: 2.3.13(fp-ts@2.16.1)
       newtype-ts: 0.3.5(fp-ts@2.16.1)(monocle-ts@2.3.13)
-      rdf-ext: 2.2.0
+      rdf-ext: 2.3.0
       readable-stream: 4.4.2
     transitivePeerDependencies:
       - web-streams-polyfill
@@ -3215,6 +3214,13 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
+  /grapoi@1.0.2:
+    resolution: {integrity: sha512-YOlMOdFjFLURx268pV3rLMt9pDszbbxbYYUKRpGjbSJFt3ubxIOqB/70sl4o8mqmaW7OYvlY8jdilT9b5bs5qA==}
+    dependencies:
+      '@rdfjs/namespace': 2.0.0
+      '@rdfjs/term-set': 2.0.1
+    dev: false
+
   /handlebars@4.7.7:
     resolution: {integrity: sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==}
     engines: {node: '>=0.4.7'}
@@ -3681,8 +3687,8 @@ packages:
       - encoding
     dev: true
 
-  /jsonld@8.2.0:
-    resolution: {integrity: sha512-qHUa9pn3/cdAZw26HY1Jmy9+sHOxaLrveTRWUcrSDx5apTa20bBTe+X4nzI7dlqc+M5GkwQW6RgRdqO6LF5nkw==}
+  /jsonld@8.3.1:
+    resolution: {integrity: sha512-tYfKpWL56meSJCHS91Ph0+EUThHZOZ8bKuboME4998SF+Kkukp2PhCPdRCvA7tsGUKr9FvSoyIRqJPuImBcBuA==}
     engines: {node: '>=14'}
     dependencies:
       '@digitalbazaar/http-client': 3.4.1
@@ -4800,8 +4806,8 @@ packages:
       readable-stream: 3.6.2
     dev: false
 
-  /rdf-ext@2.2.0:
-    resolution: {integrity: sha512-/6Z1VK+OdL4SQnxhzdN1CJJY7pmtTzh0BHLRgKQG9MPIN2SnYr/eymHxqcygcZ/YHqXAV7kl2aOFbn6u9P4Wgw==}
+  /rdf-ext@2.3.0:
+    resolution: {integrity: sha512-/2bPbKidKNBItZA/iYgQXMZncK2T9zCHkH+yFMCaRfOay0qmqo7yN7t+VIGObXimQ66EYNRQANo/EMXIPEz9eA==}
     dependencies:
       '@rdfjs/data-model': 2.0.1
       '@rdfjs/dataset': 2.0.1
@@ -4816,6 +4822,7 @@ packages:
       '@rdfjs/to-ntriples': 2.0.0
       '@rdfjs/traverser': 0.1.2
       clownface: 1.5.1
+      grapoi: 1.0.2
       readable-stream: 4.4.2
     dev: false
 
@@ -5409,11 +5416,6 @@ packages:
     engines: {node: '>=18'}
     dev: false
 
-  /streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
-    dev: false
-
   /string-to-stream@3.0.1:
     resolution: {integrity: sha512-Hl092MV3USJuUCC6mfl9sPzGloA3K5VwdIeJjYIkXY/8K+mUvaeEabWJgArp+xXrsWxCajeT2pc4axbVhIZJyg==}
     dependencies:
@@ -5646,10 +5648,10 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /ts-morph@19.0.0:
-    resolution: {integrity: sha512-D6qcpiJdn46tUqV45vr5UGM2dnIEuTGNxVhg0sk5NX11orcouwj6i1bMqZIz2mZTZB1Hcgy7C3oEVhAT+f6mbQ==}
+  /ts-morph@20.0.0:
+    resolution: {integrity: sha512-JVmEJy2Wow5n/84I3igthL9sudQ8qzjh/6i4tmYCm6IqYyKFlNbJZi7oBdjyqcWSWYRu3CtL0xbT6fS03ESZIg==}
     dependencies:
-      '@ts-morph/common': 0.20.0
+      '@ts-morph/common': 0.21.0
       code-block-writer: 12.0.0
     dev: false
 
@@ -5768,11 +5770,11 @@ packages:
     dev: true
     optional: true
 
-  /undici@5.23.0:
-    resolution: {integrity: sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==}
+  /undici@5.26.3:
+    resolution: {integrity: sha512-H7n2zmKEWgOllKkIUkLvFmsJQj062lSm3uA4EYApG8gLuiOM0/go9bIoC3HVaSnfg4xunowDE2i9p8drkXuvDw==}
     engines: {node: '>=14.0'}
     dependencies:
-      busboy: 1.6.0
+      '@fastify/busboy': 2.0.0
     dev: false
 
   /unique-string@2.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         version: 18.12.1
       docmaps-sdk:
         specifier: ^0.11.2
-        version: 0.11.2
+        version: 0.11.3
     devDependencies:
       '@types/node':
         specifier: ^18.16.2
@@ -2443,6 +2443,24 @@ packages:
     dependencies:
       path-type: 4.0.0
     dev: true
+
+  /docmaps-sdk@0.11.3:
+    resolution: {integrity: sha512-SmZBAfdeI2sWCrrc5miP9zdHde4vC+7jjAaTIKQL3sgl1vWieDGQdElKpDitqL8jJjK/e/9bMXpfWZ8Q+XX86Q==}
+    engines: {node: '>=18.14.0'}
+    dependencies:
+      '@rdfjs/data-model': 2.0.1
+      '@rdfjs/parser-n3': 2.0.1
+      '@rdfjs/serializer-jsonld-ext': 4.0.0
+      fp-ts: 2.16.1
+      io-ts: 2.2.20(fp-ts@2.16.1)
+      io-ts-types: 0.5.19(fp-ts@2.16.1)(io-ts@2.2.20)(monocle-ts@2.3.13)(newtype-ts@0.3.5)
+      monocle-ts: 2.3.13(fp-ts@2.16.1)
+      newtype-ts: 0.3.5(fp-ts@2.16.1)(monocle-ts@2.3.13)
+      rdf-ext: 2.3.0
+      readable-stream: 4.4.2
+    transitivePeerDependencies:
+      - web-streams-polyfill
+    dev: false
 
   /docmaps-sdk@0.14.0:
     resolution: {integrity: sha512-3F23bp+SEuxmO6PdwyO/Wqk+ABTvGnZ9Bqc2pOxx91z9n/hRmxQVb3PZkO3fvpZF6End1Ky+JL8sAKvkWE9T/w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,9 +132,6 @@ importers:
       fp-ts:
         specifier: ^2.14.0
         version: 2.16.1
-      immutable:
-        specifier: 5.0.0-beta.4
-        version: 5.0.0-beta.4
       isomorphic-fetch:
         specifier: ^3.0.0
         version: 3.0.0
@@ -3352,10 +3349,6 @@ packages:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
     dev: true
-
-  /immutable@5.0.0-beta.4:
-    resolution: {integrity: sha512-sl9RE3lqd2LoQSESc8VV0k8qE9y57iT7dinq3Q+8mR2dqReHDZlgUrudzmFfZhDXBLXlNJMVWv3SG1YpQIokig==}
-    dev: false
 
   /import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}


### PR DESCRIPTION
# WIP.

## Description

Adds the method `GET /docmap_for/doi`. Because it is a GET, this should be cacheable, and at the moment, this is reliant on there existing such a docmap already.

### Related Issues

Contributes to

Docmaps-Project/docmaps#144 
Docmaps-Project/docmaps#148 

### Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added or updated tests to cover any new functionality or bug fixes.
- [ ] I have updated the documentation to reflect any changes or additions to the project.
- [x] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

Open questions:

- [x] What error codes are best? How do we want to distinguish between "nothing found" and "bad data found"?
- [x] what is the result when there are multiple docmaps found that match?