### PR TITLE
fix(http-client): make docker build work again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ RUN pnpm run -r build
 # into this layer.
 FROM base AS prod
 
+RUN npm i -g typescript@4.9.5
+
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
       pnpm install \
       --prod \

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -28,6 +28,7 @@
   ],
   "dependencies": {
     "@ts-rest/core": "^3.30.2",
+    "@tsconfig/node-lts-strictest-esm": "^18.12.1",
     "docmaps-sdk": "^0.11.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@ts-rest/core':
         specifier: ^3.30.2
         version: 3.30.2(zod@3.22.2)
+      '@tsconfig/node-lts-strictest-esm':
+        specifier: ^18.12.1
+        version: 18.12.1
       docmaps-sdk:
         specifier: ^0.11.2
         version: 0.11.2


### PR DESCRIPTION
## Description

We accidentally broke the docker build, this unbreaks it.

### Related Issues

List any issues that are related to this pull request, such as bug reports or feature requests.

### Checklist

- [X] I have tested these changes locally and they work as expected.
- [ ] I have added or updated tests to cover any new functionality or bug fixes.
- [ ] I have updated the documentation to reflect any changes or additions to the project.
- [X] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

This does inflate the size of the image from 416MB to 509MB because we're including typescript now. See https://github.com/Docmaps-Project/docmaps/issues/118