### PR TITLE
feat(ts-api-server): add cors

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@rdfjs/types": "^1.1.0",
+    "@types/cors": "^2.8.14",
     "@types/express": "^4.17.17",
     "@types/isomorphic-fetch": "^0.0.36",
     "@types/n3": "^1.16.0",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -26,6 +26,7 @@
   ],
   "dependencies": {
     "@commander-js/extra-typings": "^11.0.0",
+    "@docmaps/http-client": "workspace:^0.1.0",
     "@rdfjs/data-model": "^2.0.1",
     "@rdfjs/namespace": "^2.0.0",
     "@tpluscode/sparql-builder": "^0.3.31",
@@ -34,6 +35,7 @@
     "@tsconfig/node-lts-strictest-esm": "^18.12.1",
     "@zazuko/rdf-vocabularies": "^2023.1.19",
     "commander": "^11.0.0",
+    "cors": "^2.8.5",
     "docmaps-sdk": "^0.11.2",
     "express": "^4.18.2",
     "fetch-sparql-endpoint": "^4.0.0",
@@ -43,8 +45,7 @@
     "n3": "^1.17.1",
     "oxigraph": "^0.3.19",
     "streaming-iterables": "^8.0.0",
-    "tsx": "^3.12.7",
-    "@docmaps/http-client": "workspace:^0.1.0"
+    "tsx": "^3.12.7"
   },
   "devDependencies": {
     "@rdfjs/types": "^1.1.0",

--- a/packages/runtime/src/httpserver/server.ts
+++ b/packages/runtime/src/httpserver/server.ts
@@ -8,6 +8,7 @@ import { OxigraphInmemBackend } from '../adapter/oxigraph_inmem'
 import { SparqlAdapter, SparqlFetchBackend } from '../adapter'
 import { isLeft } from 'fp-ts/lib/Either'
 import { BackendAdapter } from '../types'
+import cors from 'cors'
 
 export type ServerConfig = {
   server: {
@@ -52,6 +53,9 @@ export class HttpServer {
     this.api = new ApiInstance(adapter, new URL(config.server.apiUrl))
 
     this.app = express()
+
+    // TODO Allow CORS to be configured in production
+    this.app.use(cors())
 
     // app.use(bodyParser.urlencoded({ extended: false }))
     // app.use(bodyParser.json())

--- a/packages/runtime/test/integration/httpserver.test.ts
+++ b/packages/runtime/test/integration/httpserver.test.ts
@@ -17,6 +17,7 @@ test.serial('it serves info endpoint', async (t) => {
     const info = await client.getInfo()
 
     t.is(info.status, 200)
+    t.is(info.headers.get('Access-Control-Allow-Origin'), '*')
     t.deepEqual(info.body, {
       api_url: 'http://localhost:33033/docmaps/v1/',
       api_version: API_VERSION,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       commander:
         specifier: ^11.0.0
         version: 11.0.0
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
       docmaps-sdk:
         specifier: ^0.11.2
         version: 0.11.2
@@ -2231,6 +2234,14 @@ packages:
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
+  /cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+    dev: false
+
   /cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
@@ -4305,6 +4316,11 @@ packages:
       - validate-npm-package-name
       - which
       - write-file-atomic
+
+  /object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /object-inspect@1.12.3:
     resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       '@rdfjs/types':
         specifier: ^1.1.0
         version: 1.1.0
+      '@types/cors':
+        specifier: ^2.8.14
+        version: 2.8.14
       '@types/express':
         specifier: ^4.17.17
         version: 4.17.17
@@ -1229,6 +1232,12 @@ packages:
 
   /@types/connect@3.4.36:
     resolution: {integrity: sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==}
+    dependencies:
+      '@types/node': 18.17.4
+    dev: true
+
+  /@types/cors@2.8.14:
+    resolution: {integrity: sha512-RXHUvNWYICtbP6s18PnOCaqToK8y14DnLd75c6HfyKf228dxy7pHNOQkxPtvXKp/hINFMDjbYzsj63nnpPMSRQ==}
     dependencies:
       '@types/node': 18.17.4
     dev: true


### PR DESCRIPTION
## Description

The widget should be able to make requests to the api-server regardless of the domain where it's being hosted.

Since there is no privileged, secret information in a docmap, I believe it should be safe to allow requests from all domains. As I understand it, CORS is mostly relevant when you're trying to prevent one site from accessing credential-restricted content on another site. e.g. evil.example.com should not be able to send requests to http://mail.google.com/.

### Related Issues

N/A

### Checklist

- [X] I have tested these changes locally and they work as expected.
- [x] I have added or updated tests to cover any new functionality or bug fixes.
- [ ] I have updated the documentation to reflect any changes or additions to the project.
- [x] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

N/A